### PR TITLE
Realm: Use faster insert API

### DIFF
--- a/ORM-Benchmark/src/main/java/com/littleinc/orm_benchmark/realm/RealmExecutor.java
+++ b/ORM-Benchmark/src/main/java/com/littleinc/orm_benchmark/realm/RealmExecutor.java
@@ -95,7 +95,7 @@ public class RealmExecutor implements BenchmarkExecutable
         {
             for(User newUser : users)
             {
-                realm.copyToRealm(newUser);
+                realm.insert(newUser);
             }
 
             userLog = "Done, wrote " + NUM_USER_INSERTS + " users" + (System.nanoTime() - start);
@@ -104,7 +104,7 @@ public class RealmExecutor implements BenchmarkExecutable
 
             for(Message message : messages)
             {
-                realm.copyToRealm(message);
+                realm.insert(message);
             }
         }
         finally

--- a/ORM-Benchmark/src/main/java/com/littleinc/orm_benchmark/realm/RealmExecutor.java
+++ b/ORM-Benchmark/src/main/java/com/littleinc/orm_benchmark/realm/RealmExecutor.java
@@ -93,19 +93,13 @@ public class RealmExecutor implements BenchmarkExecutable
         long messageStart;
         try
         {
-            for(User newUser : users)
-            {
-                realm.insert(newUser);
-            }
+            realm.insert(users);
 
             userLog = "Done, wrote " + NUM_USER_INSERTS + " users" + (System.nanoTime() - start);
 
             messageStart = System.nanoTime();
 
-            for(Message message : messages)
-            {
-                realm.insert(message);
-            }
+            realm.insert(messages);
         }
         finally
         {


### PR DESCRIPTION
With the upgrade to 1.1.0, we also added a faster insert API (`insert()` and `insertOrUpdate()`) that removed a lot of the overhead in `copyToRealm`. The benchmark now uses this API instead.
